### PR TITLE
🧪 [unit test for fingerprint name mapping]

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -632,3 +632,30 @@ impl menu::action::MenuAction for MenuAction {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_finger_name() {
+        assert_eq!(map_finger_name("Right Thumb finger"), "right-thumb");
+        assert_eq!(map_finger_name("Right Index finger"), "right-index-finger");
+        assert_eq!(map_finger_name("Right Middle finger"), "right-middle-finger");
+        assert_eq!(map_finger_name("Right Ring finger"), "right-ring-finger");
+        assert_eq!(map_finger_name("Right Little finger"), "right-little-finger");
+        assert_eq!(map_finger_name("Left Thumb finger"), "left-thumb");
+        assert_eq!(map_finger_name("Left Index finger"), "left-index-finger");
+        assert_eq!(map_finger_name("Left Middle finger"), "left-middle-finger");
+        assert_eq!(map_finger_name("Left Ring finger"), "left-ring-finger");
+        assert_eq!(map_finger_name("Left Little finger"), "left-little-finger");
+        assert_eq!(map_finger_name("Some random string"), "any");
+    }
+
+    #[test]
+    fn test_map_finger_name_bidi() {
+        assert_eq!(map_finger_name("\u{2068}Right Thumb finger\u{2069}"), "right-thumb");
+        assert_eq!(map_finger_name("\u{2068}Left Index finger"), "left-index-finger");
+        assert_eq!(map_finger_name("Right Ring finger\u{2069}"), "right-ring-finger");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `map_finger_name` function in `src/app.rs`. This function is responsible for mapping localized UI finger names to the canonical names used by `fprintd`.

📊 **Coverage:**
- All 10 finger names (Right/Left Thumb, Index, Middle, Ring, Little) are now tested.
- The fallback "any" case is covered.
- Edge cases involving BiDi control characters (\u{2068} and \u{2069}) used by Fluent for localization are specifically tested.

✨ **Result:** Increased reliability of the finger name mapping logic, ensuring that UI changes or localization updates don't break the integration with `fprintd`.

---
*PR created automatically by Jules for task [8182791668731224116](https://jules.google.com/task/8182791668731224116) started by @jotuel*