### PR TITLE
⚡ Optimize finger name mapping with Page enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-fprint"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures-util",
  "i18n-embed 0.15.4",

--- a/src/app.rs
+++ b/src/app.rs
@@ -92,52 +92,52 @@ impl cosmic::Application for AppModel {
 
         nav.insert()
             .text(fl!("page-id", name = "Right Thumb"))
-            .data::<Page>(Page::Page1)
+            .data::<Page>(Page::RightThumb)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Right Index"))
-            .data::<Page>(Page::Page2)
+            .data::<Page>(Page::RightIndex)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Right Middle"))
-            .data::<Page>(Page::Page3)
+            .data::<Page>(Page::RightMiddle)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Right Ring"))
-            .data::<Page>(Page::Page4)
+            .data::<Page>(Page::RightRing)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Right Pinky"))
-            .data::<Page>(Page::Page5)
+            .data::<Page>(Page::RightPinky)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Left Thumb"))
-            .data::<Page>(Page::Page6)
+            .data::<Page>(Page::LeftThumb)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Left Index"))
-            .data::<Page>(Page::Page7)
+            .data::<Page>(Page::LeftIndex)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Left Middle"))
-            .data::<Page>(Page::Page8)
+            .data::<Page>(Page::LeftMiddle)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Left Ring"))
-            .data::<Page>(Page::Page9)
+            .data::<Page>(Page::LeftRing)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         nav.insert()
             .text(fl!("page-id", name = "Left Pinky"))
-            .data::<Page>(Page::Page10)
+            .data::<Page>(Page::LeftPinky)
             .icon(icon::from_name("applications-utilities-symbolic"));
 
         // Construct the app model with the runtime's core.
@@ -375,14 +375,11 @@ impl cosmic::Application for AppModel {
                 self.busy = false;
             }
             Message::Delete => {
-                let text = self.nav.text(self.nav.active());
-                let finger_opt: Option<String> = text.map(|s| s.to_string());
-
-                if let Some(s) = finger_opt {
+                if let Some(page) = self.nav.data::<Page>(self.nav.active()) {
                     if let Some(path) = self.device_path.clone() {
                          self.busy = true;
                          self.status = "Deleting fingerprints...".to_string();
-                         let finger_name = map_finger_name(&s);
+                         let finger_name = page.as_finger_id().to_string();
                          return Task::perform(async move {
                              match delete_fingerprint_dbus(path, finger_name).await {
                                  Ok(_) => Message::DeleteComplete,
@@ -393,14 +390,11 @@ impl cosmic::Application for AppModel {
                 }
             }
             Message::Register => {
-                let text = self.nav.text(self.nav.active());
-                let finger_opt: Option<String> = text.map(|s| s.to_string());
-
-                if let Some(s) = finger_opt {
+                if let Some(page) = self.nav.data::<Page>(self.nav.active()) {
                     if let Some(_) = &self.device_path {
                          self.busy = true;
                          self.status = "Starting enrollment...".to_string();
-                         self.enrolling_finger = Some(map_finger_name(&s));
+                         self.enrolling_finger = Some(page.as_finger_id().to_string());
                          // The subscription will pick this up automatically
                     }
                 }
@@ -504,25 +498,6 @@ impl AppModel {
 }
 
 
-// Map the UI finger name to fprintd finger name
-fn map_finger_name(name: &str) -> String {
-    let mut str = name.replace("\u{2069}", "");
-    str = str.replace("\u{2068}", "");
-    match str.as_str() {
-        "Right Thumb finger" => "right-thumb",
-        "Right Index finger" => "right-index-finger",
-        "Right Middle finger" => "right-middle-finger",
-        "Right Ring finger" => "right-ring-finger",
-        "Right Little finger" => "right-little-finger",
-        "Left Thumb finger" => "left-thumb",
-        "Left Index finger" => "left-index-finger",
-        "Left Middle finger" => "left-middle-finger",
-        "Left Ring finger" => "left-ring-finger",
-        "Left Little finger" => "left-little-finger",
-        _ => "any",
-    }.to_string()
-}
-
 async fn find_device() -> zbus::Result<zbus::zvariant::OwnedObjectPath> {
     let connection = zbus::Connection::system().await?;
     let manager = ManagerProxy::new(&connection).await?;
@@ -596,19 +571,36 @@ where S: Sink<Message> + Unpin + Send,
 }
 
 /// The page to display in the application.
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Page {
-    Page1,
+    RightThumb,
     #[default]
-    Page2,
-    Page3,
-    Page4,
-    Page5,
-    Page6,
-    Page7,
-    Page8,
-    Page9,
-    Page10,
+    RightIndex,
+    RightMiddle,
+    RightRing,
+    RightPinky,
+    LeftThumb,
+    LeftIndex,
+    LeftMiddle,
+    LeftRing,
+    LeftPinky,
+}
+
+impl Page {
+    fn as_finger_id(&self) -> &'static str {
+        match self {
+            Page::RightThumb => "right-thumb",
+            Page::RightIndex => "right-index-finger",
+            Page::RightMiddle => "right-middle-finger",
+            Page::RightRing => "right-ring-finger",
+            Page::RightPinky => "right-little-finger",
+            Page::LeftThumb => "left-thumb",
+            Page::LeftIndex => "left-index-finger",
+            Page::LeftMiddle => "left-middle-finger",
+            Page::LeftRing => "left-ring-finger",
+            Page::LeftPinky => "left-little-finger",
+        }
+    }
 }
 
 /// The context page to display in the context drawer.
@@ -633,29 +625,3 @@ impl menu::action::MenuAction for MenuAction {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_map_finger_name() {
-        assert_eq!(map_finger_name("Right Thumb finger"), "right-thumb");
-        assert_eq!(map_finger_name("Right Index finger"), "right-index-finger");
-        assert_eq!(map_finger_name("Right Middle finger"), "right-middle-finger");
-        assert_eq!(map_finger_name("Right Ring finger"), "right-ring-finger");
-        assert_eq!(map_finger_name("Right Little finger"), "right-little-finger");
-        assert_eq!(map_finger_name("Left Thumb finger"), "left-thumb");
-        assert_eq!(map_finger_name("Left Index finger"), "left-index-finger");
-        assert_eq!(map_finger_name("Left Middle finger"), "left-middle-finger");
-        assert_eq!(map_finger_name("Left Ring finger"), "left-ring-finger");
-        assert_eq!(map_finger_name("Left Little finger"), "left-little-finger");
-        assert_eq!(map_finger_name("Some random string"), "any");
-    }
-
-    #[test]
-    fn test_map_finger_name_bidi() {
-        assert_eq!(map_finger_name("\u{2068}Right Thumb finger\u{2069}"), "right-thumb");
-        assert_eq!(map_finger_name("\u{2068}Left Index finger"), "left-index-finger");
-        assert_eq!(map_finger_name("Right Ring finger\u{2069}"), "right-ring-finger");
-    }
-}


### PR DESCRIPTION
This PR optimizes the finger name mapping logic by replacing string parsing with direct enum usage.

### Changes
- **Refactored `Page` Enum:** Renamed generic `Page1`..`Page10` variants to semantic names (`RightThumb`, `RightIndex`, etc.) and derived `Copy, Clone, Debug, PartialEq, Eq`.
- **Direct Mapping:** Added `as_finger_id` method to `Page` to return the required fprintd finger ID string directly.
- **Updated Logic:** Modified `Message::Register` and `Message::Delete` to retrieve the `Page` data associated with the selected nav item using `nav.data::<Page>(...)` instead of parsing the localized button text.
- **Cleanup:** Removed the now-obsolete `map_finger_name` function and its unit tests.

### Rationale
The previous implementation relied on parsing the display text of the navigation items to determine which finger to enroll/delete. This was brittle (dependent on localization and specific string formats) and inefficient (O(N) string allocations). The new approach uses the `Page` enum as the source of truth, providing O(1) access and compile-time safety.

### Verification
- **Compilation:** Verified with `cargo check`.
- **Logic:** Reviewed code changes to ensure correct mapping and logic flow.


---
*PR created automatically by Jules for task [16016712715601677051](https://jules.google.com/task/16016712715601677051) started by @jotuel*