### PR TITLE
refactor: Remove unused `demo` field from `Config` struct

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,4 @@ use cosmic::cosmic_config::{self, CosmicConfigEntry, cosmic_config_derive::Cosmi
 
 #[derive(Debug, Default, Clone, CosmicConfigEntry, Eq, PartialEq)]
 #[version = 1]
-pub struct Config {
-    demo: String,
-}
+pub struct Config {}


### PR DESCRIPTION
Removed the unused `demo` field from the `Config` struct in `src/config.rs`. This cleanup improves maintainability by removing dead code.

---
*PR created automatically by Jules for task [16137258010544427907](https://jules.google.com/task/16137258010544427907) started by @jotuel*