### PR TITLE
Embed fprint.svg in the binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-fprint"
-version = "0.2.0"
+version = "0.3.4"
 dependencies = [
  "futures-util",
  "i18n-embed 0.15.4",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,6 +23,7 @@ use fprint::{delete_fingerprint_dbus, enroll_fingerprint_process, find_device};
 
 const REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
 const APP_ICON: &[u8] = include_bytes!("../../resources/icons/hicolor/scalable/apps/icon.svg");
+const FPRINT_ICON: &[u8] = include_bytes!("../../resources/icons/hicolor/scalable/apps/fprint.svg");
 
 /// The application model stores app-specific state used to describe its interface and
 /// drive its logic.
@@ -205,11 +206,9 @@ impl cosmic::Application for AppModel {
                     .align_y(Vertical::Center),
             )
             .push(
-                widget::svg(widget::svg::Handle::from_path(std::path::PathBuf::from(
-                    "resources/icons/hicolor/scalable/apps/fprint.svg",
-                )))
-                .width(Length::Fill)
-                .height(Length::Fill),
+                widget::svg(widget::svg::Handle::from_memory(FPRINT_ICON))
+                    .width(Length::Fill)
+                    .height(Length::Fill),
             )
             .push(
                 widget::text(&self.status)


### PR DESCRIPTION
This change modifies `src/app/mod.rs` to embed `fprint.svg` using `include_bytes!` instead of loading it from a relative path at runtime. This ensures that the icon is correctly displayed when the application is packaged as a Flatpak, where relative paths may not resolve as expected.