### PR TITLE
Remove unused DBus proxy methods

### DIFF
--- a/src/fprint_dbus.rs
+++ b/src/fprint_dbus.rs
@@ -7,7 +7,6 @@ use zbus::proxy;
 )]
 pub trait Manager {
     fn get_default_device(&self) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
-    fn get_devices(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedObjectPath>>;
 }
 
 #[proxy(
@@ -18,7 +17,6 @@ pub trait Device {
     fn claim(&self, username: &str) -> zbus::Result<()>;
     fn release(&self) -> zbus::Result<()>;
     fn list_enrolled_fingers(&self, username: &str) -> zbus::Result<Vec<String>>;
-    fn delete_enrolled_fingers(&self, username: &str) -> zbus::Result<()>;
     fn delete_enrolled_finger(&self, finger_name: &str) -> zbus::Result<()>;
     fn enroll_start(&self, finger_name: &str) -> zbus::Result<()>;
     fn enroll_stop(&self) -> zbus::Result<()>;
@@ -28,7 +26,4 @@ pub trait Device {
 
     #[zbus(property, name = "num-enroll-stages")]
     fn num_enroll_stages(&self) -> zbus::Result<i32>;
-
-    #[zbus(property, name = "scan-type")]
-    fn scan_type(&self) -> zbus::Result<String>;
 }


### PR DESCRIPTION
Removes the unused `get_devices` method from the `Manager` trait and the `delete_enrolled_fingers` method and `scan_type` property from the `Device` trait in `src/fprint_dbus.rs`. These methods were not used in the codebase and their removal improves code health and declutters the interface.

* src/fprint_dbus.rs: Remove unused methods.