### PR TITLE
feat(ci): release flatpak bundle on push to main

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -7,6 +7,9 @@ on:
     branches:
      - main
 
+permissions:
+  contents: write
+
 jobs:
   flatpak:
     runs-on: ubuntu-latest
@@ -23,3 +26,15 @@ jobs:
           bundle: cosmic-fprint.flatpak
           manifest-path: flatpak/fi.joonastuomi.CosmicFprint.yml
           cache-key: flatpak-builder-${{ github.sha }}
+
+      - name: Create Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: nightly
+          name: Nightly Build
+          files: cosmic-fprint.flatpak
+          draft: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit updates the `.github/workflows/flatpak.yml` workflow to automatically create or update a "Nightly Build" release when changes are pushed to the `main` branch. The `cosmic-fprint.flatpak` bundle is uploaded as an asset to this release.

- Adds `permissions: contents: write` to the workflow to allow release creation.
- Adds a `Create Release` step using `softprops/action-gh-release@v1`.
- Configures the release to be a prerelease with the tag `nightly`.