### PR TITLE
perf: optimize user fetching with parallel DBus queries

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::accounts_dbus::{AccountsProxy, UserProxy};
+use zbus;
 use crate::config::Config;
 use crate::fl;
 use crate::fprint_dbus::DeviceProxy;
@@ -12,6 +13,7 @@ use cosmic::iced::{Alignment, Length, Subscription};
 use cosmic::prelude::*;
 use cosmic::widget::{self, icon, menu, nav_bar, text};
 use cosmic::{cosmic_theme, theme};
+use futures_util::stream::{self, StreamExt};
 use futures_util::SinkExt;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -36,6 +38,8 @@ const STATUS_TEXT_SIZE: u16 = 16;
 const PROGRESS_BAR_HEIGHT: u16 = 10;
 const MAIN_SPACING: u16 = 20;
 const MAIN_PADDING: u16 = 20;
+
+const USER_FETCH_CONCURRENCY: usize = 10;
 
 /// The application model stores app-specific state used to describe its interface and
 /// drive its logic.
@@ -399,23 +403,28 @@ impl cosmic::Application for AppModel {
                         // Try to get users from AccountsService
                         if let Ok(accounts) = AccountsProxy::new(&conn_clone).await {
                             if let Ok(user_paths) = accounts.list_cached_users().await {
-                                for path in user_paths {
-                                    if let Ok(user_proxy) = UserProxy::builder(&conn_clone)
-                                        .path(path)
-                                        .expect("path should be valid")
-                                        .build()
-                                        .await
-                                    {
-                                        if let (Ok(name), Ok(real_name)) =
-                                            (user_proxy.user_name().await, user_proxy.real_name().await)
-                                        {
-                                            users.push(UserOption {
+                                let fetched_users: Vec<_> = stream::iter(user_paths)
+                                    .map(|path| {
+                                        let conn = conn_clone.clone();
+                                        async move {
+                                            let user_proxy = UserProxy::builder(&conn)
+                                                .path(path)
+                                                .expect("path should be valid")
+                                                .build()
+                                                .await?;
+                                            let name = user_proxy.user_name().await?;
+                                            let real_name = user_proxy.real_name().await?;
+                                            Ok::<_, zbus::Error>(UserOption {
                                                 username: Arc::new(name),
                                                 realname: Arc::new(real_name),
-                                            });
+                                            })
                                         }
-                                    }
-                                }
+                                    })
+                                    .buffer_unordered(USER_FETCH_CONCURRENCY)
+                                    .filter_map(|res| async { res.ok() })
+                                    .collect()
+                                    .await;
+                                users.extend(fetched_users);
                             }
                         }
 


### PR DESCRIPTION
Parallelize the sequential N+1 DBus queries when fetching user details from AccountsService. This uses `futures_util::stream::buffer_unordered` to fetch multiple user profiles concurrently, significantly reducing the total latency when multiple users are present in the system.

- Introduced `USER_FETCH_CONCURRENCY` constant (set to 10).
- Replaced sequential `for` loop with async stream processing.
- Ensured `zbus` and `futures_util` imports are correctly handled.
- Cleaned up temporary benchmark artifacts.