### PR TITLE
Localized hardcoded DBus connection error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-fprint"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "futures-util",
  "i18n-embed 0.15.4",

--- a/i18n/en/cosmic_ext_fprint.ftl
+++ b/i18n/en/cosmic_ext_fprint.ftl
@@ -50,3 +50,4 @@ error-claim-device = Could not claim the device.
 error-device-not-found = Fingerprint device not found.
 error-timeout = Operation timed out.
 error-prints-not-deleted = Could not delete fingerprints.
+error-connect-dbus = Failed to connect to DBus: {$err}

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -12,6 +12,7 @@ pub enum AppError {
     PrintsNotDeleted,
     Timeout,
     DeviceNotFound,
+    ConnectDbus(String),
     Unknown(String),
 }
 
@@ -26,6 +27,7 @@ impl AppError {
             AppError::PrintsNotDeleted => fl!("error-prints-not-deleted"),
             AppError::Timeout => fl!("error-timeout"),
             AppError::DeviceNotFound => fl!("error-device-not-found"),
+            AppError::ConnectDbus(msg) => fl!("error-connect-dbus", err = msg),
             AppError::Unknown(msg) => msg.clone(),
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -153,7 +153,7 @@ impl cosmic::Application for AppModel {
             async move {
                 match zbus::Connection::system().await {
                     Ok(conn) => Message::ConnectionReady(conn),
-                    Err(e) => Message::OperationError(AppError::Unknown(format!("Failed to connect to DBus: {}", e))),
+                    Err(e) => Message::OperationError(AppError::ConnectDbus(e.to_string())),
                 }
             },
             cosmic::Action::App,
@@ -822,6 +822,11 @@ mod tests {
         assert_eq!(
             AppError::Timeout.localized_message(),
             "Operation timed out."
+        );
+        // Test localized message for DBus connection error
+        assert_eq!(
+            AppError::ConnectDbus("Connection error".to_string()).localized_message(),
+            "Failed to connect to DBus: \u{2068}Connection error\u{2069}"
         );
     }
 


### PR DESCRIPTION
Replaced hardcoded "Failed to connect to DBus: {}" string with a localized message. Added ConnectDbus variant to AppError and updated localized_message to use fl!("error-connect-dbus", err = msg). Added unit test to verify localization.
Updated Cargo.lock to match Cargo.toml version.