### PR TITLE
perf: Cache and reuse DBus DeviceProxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-fprint"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "futures-util",
  "i18n-embed 0.15.4",

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -4,6 +4,7 @@ use crate::config::Config;
 use crate::app::page::ContextPage;
 use std::sync::Arc;
 use crate::app::error::AppError;
+use crate::fprint_dbus::DeviceProxy;
 
 /// Messages emitted by the application and its widgets.
 #[derive(Debug, Clone)]
@@ -15,7 +16,7 @@ pub enum Message {
     Delete,
     Register,
     ConnectionReady(zbus::Connection),
-    DeviceFound(Option<zbus::zvariant::OwnedObjectPath>),
+    DeviceFound(Option<(zbus::zvariant::OwnedObjectPath, DeviceProxy<'static>)>),
     OperationError(AppError),
     EnrollStart(Option<u32>),
     EnrollStatus(String, bool),


### PR DESCRIPTION
Avoid creating a new DeviceProxy for every `list_enrolled_fingers` call. Instead, create it once when the device is found and store it in `AppModel`. This reduces allocation overhead and potential DBus introspection traffic.

Changes:
- `AppModel` now stores `Option<DeviceProxy<'static>>`.
- `find_device` returns both the object path and the proxy.
- `list_enrolled_fingers_dbus` accepts a reference to an existing proxy.
- `Message::DeviceFound` carries the proxy along with the path.