### PR TITLE
Replace insecure USER env var with nix::unistd::User::from_uid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,12 +1030,13 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-fprint"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "futures-util",
  "i18n-embed 0.15.4",
  "i18n-embed-fl 0.9.4",
  "libcosmic",
+ "nix 0.31.1",
  "open",
  "rust-embed",
  "serde",
@@ -2860,9 +2861,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.179"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libcosmic"
@@ -3262,6 +3263,18 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ vergen = { version = "8", features = ["git", "gitcl"] }
 [dependencies]
 futures-util = "0.3.31"
 i18n-embed-fl = "0.9.2"
+nix = { version = "0.31.1", features = ["user"] }
 open = "5.3.0"
 rust-embed = "8.5.0"
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
This change addresses a security vulnerability where the `USER` environment variable was used to determine the current user identity. This variable can be spoofed by an attacker, potentially leading to privilege escalation or unauthorized actions.

We now use `nix::unistd::User::from_uid(Uid::current())` to securely determine the current user based on the effective user ID. This ensures that the application operates on the correct user account.

The `nix` dependency was added to `Cargo.toml` to support this functionality.

The logic in `src/app/mod.rs` was updated in two places:
1. Initializing `selected_user`.
2. Fallback logic when `AccountsService` returns no users.

Verification:
- `cargo check` passes.
- `cargo test` passes.
- Dependencies installed: `libxkbcommon-dev`, `libdbus-1-dev`, `libglib2.0-dev`, `libwayland-dev`.