### PR TITLE
Update Czech, fix metainfo typo & reorder paragraphs

### DIFF
--- a/i18n/cs/cosmic_utils_enroll.ftl
+++ b/i18n/cs/cosmic_utils_enroll.ftl
@@ -9,15 +9,15 @@ register = Registrovat
 verify = Ověřit
 delete = Smazat
 danger = Varování
+cancel = Zrušit
 success = Hotovo. Nyní zaregistrujte otisk.
 deleted = Otisk byl smazán.
 deleting = Mazání otisku...
 clear-device = Vymazat zařízení
 confirm-clear = Jste si jistí?
-clearing-device = Mažou se všechny otisky ze zařízení pro všechny známé uživatele...
+clearing-device = Mazání všech otisků ze zařízení pro všechny známé uživatele...
 device-cleared = Zařízení bylo vymazáno pro všechny známé uživatele.
 clear-device-confirm = Opravdu chcete vymazat otisky pro VŠECHNY známé uživatele?
-cancel = Zrušit
 
 settings-ui = Uživatelské rozhraní
 alternative-ui = Alternativní UI

--- a/resources/org.cosmic_utils.enroll.metainfo.xml
+++ b/resources/org.cosmic_utils.enroll.metainfo.xml
@@ -16,20 +16,8 @@
     <p>
       Fingerprint record management for single and multi-user systems. You can register, verify and delete prints.
     </p>
-    <p>
-      Select the user you wish to register, by default the current user, and then the finger. Click either Register to enroll a print for a new finger, Verify to match against an existing one or Delete to remove it.
-    </p>
-    <p>
-      From View menu you can access Settings where you can configure appearance or access Delete all option, which attempts to clear all registered prints from your scanner device.
-    </p>
     <p xml:lang="cs">
       Správa otisků prstů pro jednoho i více uživatelů. Umožňuje registrovat, ověřovat a mazat otisky.
-    </p>
-    <p xml:lang="cs">
-      Vyberte uživatele, pro kterého chcete otisk zaregistrovat (výchozí je aktuální uživatel), a poté prst. Klikněte na „Registrovat“ pro přidání nového otisku, „Ověřit“ pro porovnání s existujícím otiskem nebo „Smazat“ pro jeho odstranění.
-    </p>
-    <p xml:lang="cs">
-      V nabídce „Zobrazení“ najdete „Nastavení“, kde můžete upravit vzhled aplikace, nebo použít volbu „Smazat vše“, která se pokusí odstranit všechny registrované otisky ze zařízení snímače.
     </p>
     <p xml:lang="fi">
       Sormenjälkien hallinnointi yhden ja useamman käyttäjän järjestelmille. Sallii sinun luoda, varmentaa sekä poistaa jälkiä.
@@ -39,6 +27,18 @@
     </p>
     <p xml:lang="it">
       Gestione delle impronte digitali per sistemi monoutente e multiutente. Consente di creare, verificare ed eliminare le impronte digitali.
+    </p>
+    <p>
+      Select the user you wish to register, by default the current user, and then the finger. Click either Register to enroll a print for a new finger, Verify to match against an existing one or Delete to remove it.
+    </p>
+    <p xml:lang="cs">
+      Vyberte uživatele, pro kterého chcete otisk zaregistrovat (výchozí je aktuální uživatel), a poté prst. Klikněte na „Registrovat“ pro přidání nového otisku, „Ověřit“ pro porovnání s existujícím otiskem nebo „Smazat“ pro jeho odstranění.
+    </p>
+    <p>
+      From View menu you can access Settings where you can configure appearance or access Delete all option, which attempts to clear all registered prints from your scanner device.
+    </p>
+    <p xml:lang="cs">
+      V nabídce „Zobrazení“ najdete „Nastavení“, kde můžete upravit vzhled aplikace, nebo použít volbu „Smazat vše“, která se pokusí odstranit všechny registrované otisky ze zařízení snímače.
     </p>
   </description>
   <icon type="remote" width="64" height="64" scale="1">

--- a/resources/org.cosmic_utils.enroll.metainfo.xml
+++ b/resources/org.cosmic_utils.enroll.metainfo.xml
@@ -17,7 +17,7 @@
       Fingerprint record management for single and multi-user systems. You can register, verify and delete prints.
     </p>
     <p>
-      Select the user you which to register, by default the current user, and then the finger. Click either Register to enroll a print for a new finger, Verify to match against an existing one or Delete to remove it.
+      Select the user you wish to register, by default the current user, and then the finger. Click either Register to enroll a print for a new finger, Verify to match against an existing one or Delete to remove it.
     </p>
     <p>
       From View menu you can access Settings where you can configure appearance or access Delete all option, which attempts to clear all registered prints from your scanner device.

--- a/resources/org.cosmic_utils.enroll.metainfo.xml
+++ b/resources/org.cosmic_utils.enroll.metainfo.xml
@@ -25,6 +25,12 @@
     <p xml:lang="cs">
       Správa otisků prstů pro jednoho i více uživatelů. Umožňuje registrovat, ověřovat a mazat otisky.
     </p>
+    <p xml:lang="cs">
+      Vyberte uživatele, pro kterého chcete otisk zaregistrovat (výchozí je aktuální uživatel), a poté prst. Klikněte na „Registrovat“ pro přidání nového otisku, „Ověřit“ pro porovnání s existujícím otiskem nebo „Smazat“ pro jeho odstranění.
+    </p>
+    <p xml:lang="cs">
+      V nabídce „Zobrazení“ najdete „Nastavení“, kde můžete upravit vzhled aplikace, nebo použít volbu „Smazat vše“, která se pokusí odstranit všechny registrované otisky ze zařízení snímače.
+    </p>
     <p xml:lang="fi">
       Sormenjälkien hallinnointi yhden ja useamman käyttäjän järjestelmille. Sallii sinun luoda, varmentaa sekä poistaa jälkiä.
     </p>


### PR DESCRIPTION
I intentionally split this into 3 commits, so that I can quickly and easily revert them, in the case you don't like some of the changes.

- Commit 1 - updates Czech translation
- Commit 2 - fixes obvious typo
  - Select the user you (which -> wish) to register.
- Commit 3 - reorders description paragraphs, so that every localized paragraph is under the original one