### PR TITLE
fix: remove incorrect project group tag

### DIFF
--- a/resources/org.cosmic_utils.enroll.metainfo.xml
+++ b/resources/org.cosmic_utils.enroll.metainfo.xml
@@ -53,6 +53,7 @@
   <launchable type="desktop-id">org.cosmic_utils.enroll.desktop</launchable>
   <provides>
     <binary>cosmic-utils-enroll</binary>
+    <id>com.system76.CosmicApplication</id>
   </provides>
   <requires>
     <display_length compare="ge">360</display_length>

--- a/resources/org.cosmic_utils.enroll.metainfo.xml
+++ b/resources/org.cosmic_utils.enroll.metainfo.xml
@@ -2,7 +2,6 @@
 <component type="desktop-application">
   <id>org.cosmic_utils.enroll</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_group>COSMIC</project_group>
   <project_license>MPL-2.0</project_license>
   <name>Enroll</name>
   <summary>Fingerprint record management</summary>


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

Closes #135, #136 