### PR TITLE
ci: open Flathub update PR directly via create-pull-request

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,8 +74,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Regenerate cargo-sources & update manifest
+        id: prep
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
           # The git tag pushed by `just release` (e.g. v1.3.0).
           TAG: ${{ github.ref_name }}
         run: |
@@ -83,7 +83,11 @@ jobs:
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           COMMIT="${{ github.sha }}"
           echo "version=$VERSION tag=$TAG commit=$COMMIT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+          # Clone the Flathub manifest repository. create-pull-request pushes
+          # the update branch directly here (no fork) — the Flathub-maintainer
+          # pattern for opening update PRs on upstream tag creation.
           git clone https://github.com/flathub/org.cosmic_utils.enroll.git flatpak-repo
 
           # Pinned + checksummed cargo source generator (was an unpinned curl|python).
@@ -97,28 +101,18 @@ jobs:
           python3 .github/workflows/scripts/update-manifest.py \
             flatpak-repo/org.cosmic_utils.enroll.yml "$TAG" "$COMMIT"
 
-          cd flatpak-repo
-          git remote add fork "https://x-access-token:${GH_TOKEN}@github.com/jotuel/org.cosmic_utils.enroll.git"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          BRANCH="update-to-${VERSION}"
-          git checkout -b "$BRANCH"
-          git add org.cosmic_utils.enroll.yml cargo-sources.json
-          if git diff --quiet --cached; then
-            echo "No changes; Flathub manifest already up to date."
-            exit 0
-          fi
-          git commit -m "Update to version ${VERSION}"
-          git push -f fork "$BRANCH"
-
-          PR_EXISTS=$(gh pr list --repo flathub/org.cosmic_utils.enroll \
-            --head "jotuel:${BRANCH}" --json number --jq '.[0].number')
-          if [ -z "$PR_EXISTS" ]; then
-            gh pr create --repo flathub/org.cosmic_utils.enroll \
-              --title "Update to version ${VERSION}" \
-              --body "Automated update to cosmic-utils-enroll version ${VERSION}" \
-              --head "jotuel:${BRANCH}" --base master
-          else
-            echo "Pull request already exists: #$PR_EXISTS"
-          fi
+      - name: Open/update Flathub PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # PAT with write access to flathub/org.cosmic_utils.enroll; used for
+          # both pushing the branch and opening the PR in the same repository.
+          # If there are no changes the action exits without creating a PR.
+          token: ${{ secrets.GH_PAT }}
+          path: flatpak-repo
+          base: master
+          branch: update-to-${{ steps.prep.outputs.version }}
+          author: Joonas Tuomi <102735115+jotuel@users.noreply.github.com>
+          commit-message: Update to version ${{ steps.prep.outputs.version }}
+          title: Update to version ${{ steps.prep.outputs.version }}
+          body: |
+            Automated update to cosmic-utils-enroll version ${{ steps.prep.outputs.version }}.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,22 +61,33 @@ silently skips another:
 - **appimage** — `cargo build --release`, package with `appimagetool`, upload
   to the release. Needs `create-release` (a release must exist to attach to).
 - **flathub** — regenerates `cargo-sources.json` with a **pinned +
-  checksummed** cargo generator, updates the manifest, force-pushes to your
-  fork and opens/updates the Flathub PR. Fully parallel to `appimage`.
+  checksummed** cargo generator, updates the manifest, then uses
+  [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request)
+  to push an update branch directly to `flathub/org.cosmic_utils.enroll` and
+  open/update the PR there (no fork — the Flathub maintainer pattern). Fully
+  parallel to `appimage`.
 
 ## Required repository configuration
 
 ### `GH_PAT` (for the Flathub job only)
 
-The workflow pushes to your fork `jotuel/org.cosmic_utils.enroll` and opens a
-PR on `flathub/org.cosmic_utils.enroll` using a PAT. The PAT must have:
+The workflow pushes a branch directly to `flathub/org.cosmic_utils.enroll`
+and opens the PR there (no fork), using a PAT. Your account already has write
+access to the Flathub repo (standard for the upstream author), so a **classic
+PAT with the `repo` scope** is all that's needed — the classic `repo` scope
+inherits your collaborator rights and works against the Flathub repo at
+runtime.
 
-- **Contents: write** on `jotuel/org.cosmic_utils.enroll` (fine-grained), or
-  the `repo` scope (classic).
+> **Use a classic PAT, not fine-grained.** Fine-grained PATs can only target
+> repositories you *own*, so `flathub/org.cosmic_utils.enroll` (where you're a
+> collaborator, not the owner) does not appear in their repository picker. A
+> classic PAT with `repo` scope has no such limitation. This is why the
+> Flathub docs say *"the maintainer can use their personal token for this."*
 
-Store it as the repository secret **`GH_PAT`**. If the Flathub job fails with
-`403 ... denied to jotuel`, the PAT is missing this scope (this is exactly
-what failed before).
+Create it at *Settings → Developer settings → Personal access tokens → Tokens
+(classic)*, give it the **`repo`** scope, and store it as the repository
+secret **`GH_PAT`**. If the Flathub job fails with `403 ... denied to
+flathub`, the PAT is missing the `repo` scope.
 
 ### GitHub Actions settings
 

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -497,6 +497,7 @@ impl AppModel {
         };
         command::set_theme(theme)
     }
+
     pub fn on_theme_setting(&mut self, theme: AppTheme) -> Task<cosmic::Action<Message>> {
         let mut tasks = vec![self.on_update_config(Config {
             app_theme: theme,


### PR DESCRIPTION
## Summary

Switches the Flathub job in the publish workflow from the manual `git push` + `gh pr create` approach (routed through the `jotuel` fork) to [`peter-evans/create-pull-request@v7`](https://github.com/peter-evans/create-pull-request), pushing the update branch **directly** to `flathub/org.cosmic_utils.enroll` and opening the PR within the same repo — no fork.

This is the [Flathub-documented maintainer pattern](https://docs.flathub.org/docs/for-upstream-maintainers/requirements/#custom-triggered-from-an-external-repository) for sending update PRs on upstream tag creation.

## Changes

**`.github/workflows/publish.yml`** — the `flathub` job:
- Split into a prep step (`id: prep`, exposes `version` as a step output) and a `peter-evans/create-pull-request@v7` step.
- Drops ~25 lines of hand-rolled branch/commit/push/PR-dedup logic. CCR now handles:
  - **no changes → skip** (built-in)
  - **PR already exists → update** in place
- Pushes branch `update-to-<VERSION>` straight to `flathub/org.cosmic_utils.enroll` (`path: flatpak-repo`, `base: master`).
- Sets the commit `author` to the upstream maintainer's GitHub account.

**`RELEASING.md`** — updates the `GH_PAT` section:
- Now specifies a **classic** PAT with the `repo` scope.
- Documents *why* fine-grained PATs don't work here (they can't target repos you don't own; the Flathub repo is one where you're a collaborator, not owner).
- Updates the job description and the `403` troubleshooting hint (`denied to flathub`).

## Notes

- Flathub repo default branch confirmed as `master` → `base: master`.
- Requires `GH_PAT` to be a classic PAT with `repo` scope (verified working).