### PR TITLE
fix: robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ repo/
 build/
 builddir/
 vendor.tar
+Screenshot*

--- a/src/app/application.rs
+++ b/src/app/application.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 use crate::app::{
-    ContextPage, MenuAction, finger::*, message::Message, subscription::*, tasks::task_connect,
-    users::*,
+    ContextPage, MenuAction,
+    finger::*,
+    message::Message,
+    subscription::*,
+    tasks::{task_connect, task_load_users},
 };
 use crate::config::{Config, read_config};
 use crate::fl;
@@ -43,9 +46,6 @@ impl cosmic::Application for AppModel {
         mut core: cosmic::Core,
         _flags: Self::Flags,
     ) -> (Self, Task<cosmic::Action<Self::Message>>) {
-        // Gets users
-        let (users, nav, selected_user) = initialize_users();
-
         // Load configuration
         let (config_handler, config) = read_config(Self::APP_ID);
 
@@ -55,7 +55,7 @@ impl cosmic::Application for AppModel {
         let mut app = AppModel {
             core,
             context_page: ContextPage::About,
-            nav,
+            nav: nav_bar::Model::default(),
             key_binds: HashMap::new(),
             config,
             config_handler,
@@ -69,8 +69,8 @@ impl cosmic::Application for AppModel {
             verifying_finger: false,
             enroll_progress: 0,
             enroll_total_stages: None,
-            users,
-            selected_user,
+            users: Vec::new(),
+            selected_user: None,
             selected_finger: Finger::default(),
             enrolled_fingers: Vec::new(),
             confirm_clear: false,
@@ -80,8 +80,12 @@ impl cosmic::Application for AppModel {
         let start_theme = cosmic::command::set_theme(app.config.app_theme.theme());
         let command = app.update_title_task();
         let connect_task = task_connect();
+        let users_task = task_load_users();
 
-        (app, Task::batch(vec![command, connect_task, start_theme]))
+        (
+            app,
+            Task::batch(vec![command, connect_task, users_task, start_theme]),
+        )
     }
 
     /// Elements to pack at the start of the header bar.
@@ -281,6 +285,7 @@ impl cosmic::Application for AppModel {
             Message::ThemeSetting(theme) => self.on_theme_setting(theme),
             Message::SelectFingerByNumber(key) => self.on_select_finger_by_number(key),
             Message::SelectDevice(index) => self.on_select_device(index),
+            Message::UsersLoaded(users) => self.on_users_loaded(users),
         }
     }
 

--- a/src/app/finger.rs
+++ b/src/app/finger.rs
@@ -91,6 +91,12 @@ impl Finger {
     }
 }
 
+impl std::fmt::Display for Finger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.localized_name())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/app/finger.rs
+++ b/src/app/finger.rs
@@ -18,7 +18,6 @@ pub enum Finger {
     LeftMiddle,
     LeftRing,
     LeftPinky,
-    DeleteAllUsersPrints,
 }
 
 impl Finger {
@@ -35,7 +34,6 @@ impl Finger {
             Self::LeftMiddle,
             Self::LeftRing,
             Self::LeftPinky,
-            Self::DeleteAllUsersPrints,
         ]
     }
 
@@ -52,7 +50,6 @@ impl Finger {
             Self::LeftMiddle => fl!("page-left-middle-finger"),
             Self::LeftRing => fl!("page-left-ring-finger"),
             Self::LeftPinky => fl!("page-left-little-finger"),
-            Self::DeleteAllUsersPrints => fl!("page-delete-all-users-prints"),
         }
     }
 
@@ -74,19 +71,18 @@ impl Finger {
     }
 
     /// Maps to fprintd API name
-    pub fn as_finger_id(&self) -> Option<&'static str> {
+    pub fn as_finger_id(&self) -> &'static str {
         match self {
-            Finger::RightThumb => Some("right-thumb"),
-            Finger::RightIndex => Some("right-index-finger"),
-            Finger::RightMiddle => Some("right-middle-finger"),
-            Finger::RightRing => Some("right-ring-finger"),
-            Finger::RightPinky => Some("right-little-finger"),
-            Finger::LeftThumb => Some("left-thumb"),
-            Finger::LeftIndex => Some("left-index-finger"),
-            Finger::LeftMiddle => Some("left-middle-finger"),
-            Finger::LeftRing => Some("left-ring-finger"),
-            Finger::LeftPinky => Some("left-little-finger"),
-            Finger::DeleteAllUsersPrints => None,
+            Finger::RightThumb => "right-thumb",
+            Finger::RightIndex => "right-index-finger",
+            Finger::RightMiddle => "right-middle-finger",
+            Finger::RightRing => "right-ring-finger",
+            Finger::RightPinky => "right-little-finger",
+            Finger::LeftThumb => "left-thumb",
+            Finger::LeftIndex => "left-index-finger",
+            Finger::LeftMiddle => "left-middle-finger",
+            Finger::LeftRing => "left-ring-finger",
+            Finger::LeftPinky => "left-little-finger",
         }
     }
 }
@@ -104,7 +100,7 @@ mod tests {
     #[test]
     fn test_page_all() {
         let pages = Finger::all();
-        assert_eq!(pages.len(), 11);
+        assert_eq!(pages.len(), 10);
         assert_eq!(pages[0], Finger::RightThumb);
         assert_eq!(pages[1], Finger::RightIndex);
         assert_eq!(pages[2], Finger::RightMiddle);
@@ -115,7 +111,6 @@ mod tests {
         assert_eq!(pages[7], Finger::LeftMiddle);
         assert_eq!(pages[8], Finger::LeftRing);
         assert_eq!(pages[9], Finger::LeftPinky);
-        assert_eq!(pages[10], Finger::DeleteAllUsersPrints);
     }
 
     #[test]
@@ -132,7 +127,6 @@ mod tests {
         assert!(!Finger::LeftMiddle.localized_name().is_empty());
         assert!(!Finger::LeftRing.localized_name().is_empty());
         assert!(!Finger::LeftPinky.localized_name().is_empty());
-        assert!(!Finger::DeleteAllUsersPrints.localized_name().is_empty());
     }
 
     #[test]
@@ -152,28 +146,15 @@ mod tests {
 
     #[test]
     fn test_page_as_finger_id() {
-        assert_eq!(Finger::RightThumb.as_finger_id(), Some("right-thumb"));
-        assert_eq!(
-            Finger::RightIndex.as_finger_id(),
-            Some("right-index-finger")
-        );
-        assert_eq!(
-            Finger::RightMiddle.as_finger_id(),
-            Some("right-middle-finger")
-        );
-        assert_eq!(Finger::RightRing.as_finger_id(), Some("right-ring-finger"));
-        assert_eq!(
-            Finger::RightPinky.as_finger_id(),
-            Some("right-little-finger")
-        );
-        assert_eq!(Finger::LeftThumb.as_finger_id(), Some("left-thumb"));
-        assert_eq!(Finger::LeftIndex.as_finger_id(), Some("left-index-finger"));
-        assert_eq!(
-            Finger::LeftMiddle.as_finger_id(),
-            Some("left-middle-finger")
-        );
-        assert_eq!(Finger::LeftRing.as_finger_id(), Some("left-ring-finger"));
-        assert_eq!(Finger::LeftPinky.as_finger_id(), Some("left-little-finger"));
-        assert_eq!(Finger::DeleteAllUsersPrints.as_finger_id(), None);
+        assert_eq!(Finger::RightThumb.as_finger_id(), "right-thumb");
+        assert_eq!(Finger::RightIndex.as_finger_id(), "right-index-finger");
+        assert_eq!(Finger::RightMiddle.as_finger_id(), "right-middle-finger");
+        assert_eq!(Finger::RightRing.as_finger_id(), "right-ring-finger");
+        assert_eq!(Finger::RightPinky.as_finger_id(), "right-little-finger");
+        assert_eq!(Finger::LeftThumb.as_finger_id(), "left-thumb");
+        assert_eq!(Finger::LeftIndex.as_finger_id(), "left-index-finger");
+        assert_eq!(Finger::LeftMiddle.as_finger_id(), "left-middle-finger");
+        assert_eq!(Finger::LeftRing.as_finger_id(), "left-ring-finger");
+        assert_eq!(Finger::LeftPinky.as_finger_id(), "left-little-finger");
     }
 }

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -217,6 +217,9 @@ impl AppModel {
     ///
     /// **Returns** ***Task***()
     pub(crate) fn on_verify_finger(&mut self) -> Task<cosmic::Action<Message>> {
+        if self.busy {
+            return Task::none();
+        }
         if self
             .selected_finger
             .as_finger_id()
@@ -342,6 +345,10 @@ impl AppModel {
     ///
     /// **Returns** either ***Task***() or ***task_clear_device***()
     pub(crate) fn on_clear_device(&mut self) -> Task<cosmic::Action<Message>> {
+        if self.busy {
+            return Task::none();
+        }
+
         if !self.confirm_clear {
             self.confirm_clear = true;
             return Task::none();
@@ -361,6 +368,10 @@ impl AppModel {
     ///
     /// **Returns** either ***Task***(), ***task_delete_print***() or ***task_delete_prints***()
     pub(crate) fn on_delete(&mut self) -> Task<cosmic::Action<Message>> {
+        if self.busy {
+            return Task::none();
+        }
+
         if let (Some(path), Some(conn), Some(user)) = (
             self.device_path.clone(),
             self.connection.clone(),
@@ -533,11 +544,12 @@ impl AppModel {
         }
 
         if let Some(device) = self.devices.get(index)
-            && let Some(conn) = &self.connection {
-                self.status = fl!("status-searching-device");
-                self.busy = true;
-                return task_select_device(conn.clone(), device.path.clone());
-            }
+            && let Some(conn) = &self.connection
+        {
+            self.status = fl!("status-searching-device");
+            self.busy = true;
+            return task_select_device(conn.clone(), device.path.clone());
+        }
         Task::none()
     }
 

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -3,7 +3,10 @@
 use crate::app::AppModel;
 use crate::app::error::AppError;
 use crate::app::tasks::*;
-use crate::app::{ContextPage, Finger};
+use crate::app::{
+    ContextPage, Finger,
+    users::{UserOption, build_nav},
+};
 use crate::config::{AppTheme, Config};
 use crate::fl;
 use crate::fprint_dbus::DeviceProxy;
@@ -54,6 +57,7 @@ pub enum Message {
     ThemeSetting(AppTheme),
     SelectFingerByNumber(u8),
     SelectDevice(usize),
+    UsersLoaded(Vec<UserOption>),
 }
 
 // Section for handling of Messages
@@ -572,5 +576,20 @@ impl AppModel {
             self.selected_finger = fingers[next as usize];
         }
         Task::none()
+    }
+
+    /// Handles asynchronously loaded user list, builds nav bar and selects current user.
+    ///
+    /// **Returns** ***update_title_task***() and ***list_fingers_task***()
+    pub(crate) fn on_users_loaded(
+        &mut self,
+        users: Vec<UserOption>,
+    ) -> Task<cosmic::Action<Message>> {
+        let (nav, selected_user) = build_nav(&users);
+        self.nav = nav;
+        self.users = users;
+        self.selected_user = selected_user;
+
+        Task::batch(vec![self.update_title_task(), self.list_fingers_task()])
     }
 }

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -324,8 +324,8 @@ impl AppModel {
             self.enrolling_finger = None;
 
             if status == "enroll-completed" {
-                let _ = self.on_cycle_finger(1);
-                return self.list_fingers_task();
+                let cycle = self.on_cycle_finger(1);
+                return Task::batch(vec![cycle, self.list_fingers_task()]);
             }
         }
         Task::none()

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -114,11 +114,11 @@ impl AppModel {
         self.connection = Some(conn.clone());
         self.status = fl!("status-searching-device");
 
-        let conn_clone = conn.clone();
-        let clone_conn = conn.clone();
+        let find_conn = conn.clone();
+        let devices_conn = conn.clone();
         Task::batch(vec![
-            task_find_device(conn_clone),
-            get_devices_task(clone_conn),
+            task_find_device(find_conn),
+            get_devices_task(devices_conn),
         ])
     }
 

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -46,7 +46,7 @@ pub enum Message {
     ClearComplete(Result<(), AppError>),
     CloseApplication,
     EnrolledFingers(Vec<String>),
-    FingerSelected(String),
+    FingerSelected(Finger),
     VerifyFinger,
     VerifyStatus(String, bool),
     VerifyStop,
@@ -140,10 +140,11 @@ impl AppModel {
     ///
     /// **Returns** ***Task***()
     pub(crate) fn on_error(&mut self, err: AppError) -> Task<cosmic::Action<Message>> {
-        self.status = err.localized_message();
-        if self.status == fl!("error-no-enrolled-prints") {
+        if err == AppError::NoEnrolledPrints {
             self.enrolled_fingers.clear();
             self.status = fl!("success");
+        } else {
+            self.status = err.localized_message();
         }
         self.busy = false;
         self.enrolling_finger = None;
@@ -165,17 +166,12 @@ impl AppModel {
     /// the selected one
     ///
     /// **Returns** ***Task***()
-    pub(crate) fn on_finger_selected(&mut self, finger: String) -> Task<cosmic::Action<Message>> {
+    pub(crate) fn on_finger_selected(&mut self, finger: Finger) -> Task<cosmic::Action<Message>> {
         if self.busy {
             return Task::none();
         }
         self.confirm_clear = false;
-        for fingers in Finger::all() {
-            if fingers.localized_name() == finger {
-                self.selected_finger = *fingers;
-                break;
-            }
-        }
+        self.selected_finger = finger;
         Task::none()
     }
 

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -225,9 +225,9 @@ impl AppModel {
             return Task::none();
         }
         if self
-            .selected_finger
-            .as_finger_id()
-            .is_some_and(|id| self.enrolled_fingers.iter().any(|ef| ef == id))
+            .enrolled_fingers
+            .iter()
+            .any(|ef| ef == self.selected_finger.as_finger_id())
         {
             self.busy = true;
             self.verifying_finger = true;
@@ -368,9 +368,9 @@ impl AppModel {
         Task::none()
     }
 
-    /// Deletes chosen print or users all prints depending on choices from the user
+    /// Deletes the selected finger's print for the current user.
     ///
-    /// **Returns** either ***Task***(), ***task_delete_print***() or ***task_delete_prints***()
+    /// **Returns** either ***Task***() or ***task_delete_print***()
     pub(crate) fn on_delete(&mut self) -> Task<cosmic::Action<Message>> {
         if self.busy {
             return Task::none();
@@ -386,12 +386,8 @@ impl AppModel {
             let path = (*path).clone();
             let username = (*user.username).clone();
 
-            if let Some(finger_name) = self.selected_finger.as_finger_id() {
-                let finger_name = finger_name.to_string();
-                return task_delete_print(path, username, finger_name, conn);
-            } else {
-                return task_delete_prints(path, username, conn);
-            }
+            let finger_name = self.selected_finger.as_finger_id().to_string();
+            return task_delete_print(path, username, finger_name, conn);
         }
         Task::none()
     }
@@ -407,7 +403,7 @@ impl AppModel {
             self.enrolled_fingers.clear();
         } else {
             self.enrolled_fingers
-                .retain(|f| Some(f.as_str()) != self.selected_finger.as_finger_id());
+                .retain(|f| f.as_str() != self.selected_finger.as_finger_id());
         }
 
         Task::none()
@@ -471,9 +467,7 @@ impl AppModel {
     pub(crate) fn on_register(&mut self) -> Task<cosmic::Action<Message>> {
         if !self.busy && self.device_path.is_some() && self.enrolling_finger.is_none() {
             self.busy = true;
-            if let Some(finger_id) = self.selected_finger.as_finger_id() {
-                self.enrolling_finger = Some(Arc::new(finger_id.to_string()));
-            }
+            self.enrolling_finger = Some(Arc::new(self.selected_finger.as_finger_id().to_string()));
             self.status = fl!("status-starting-enrollment");
         }
         Task::none()
@@ -557,18 +551,14 @@ impl AppModel {
         Task::none()
     }
 
-    /// Cycles through selectable fingers (excludes DeleteAllUsersPrints).
+    /// Cycles through selectable fingers.
     ///
     /// **Returns** ***Task***()
     pub(crate) fn on_cycle_finger(&mut self, direction: i8) -> Task<cosmic::Action<Message>> {
         if self.busy {
             return Task::none();
         }
-        let fingers: Vec<Finger> = Finger::all()
-            .iter()
-            .filter(|f| f.as_finger_id().is_some())
-            .copied()
-            .collect();
+        let fingers = Finger::all();
         if let Some(pos) = fingers.iter().position(|f| *f == self.selected_finger) {
             let len = fingers.len() as i8;
             let next = ((pos as i8 + direction) % len + len) % len;

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -512,15 +512,15 @@ impl AppModel {
     }
 
     pub fn on_theme_setting(&mut self, theme: AppTheme) -> Task<cosmic::Action<Message>> {
-        let mut tasks = vec![self.on_update_config(Config {
-            app_theme: theme,
-            ..self.config.clone()
-        })];
+        self.config.app_theme = theme;
 
-        let task = cosmic::command::set_theme(theme.theme());
+        if let Some(handler) = &self.config_handler
+            && let Err(err) = self.config.write_entry(handler)
+        {
+            tracing::error!("failed to write config: {}", err);
+        }
 
-        tasks.push(task);
-        Task::batch(tasks)
+        cosmic::command::set_theme(theme.theme())
     }
 
     /// Selects a finger by numeric key (1-0).

--- a/src/app/subscription.rs
+++ b/src/app/subscription.rs
@@ -104,20 +104,10 @@ pub(crate) fn verify_subscription(data: VerifyData) -> Subscription<Message> {
     Subscription::run_with(data, |data| {
         let data = data.clone();
         channel(100, move |mut output: Sender<Message>| async move {
-            let Some(finger_id) = data.finger.as_finger_id() else {
-                let _ = output
-                    .send(Message::OperationError(AppError::Unknown(
-                        "Cannot verify: no valid finger selected".to_string(),
-                    )))
-                    .await;
-                futures_util::future::pending::<()>().await;
-                return;
-            };
-
             match verify_finger_process(
                 data.connection,
                 &data.device_path,
-                finger_id,
+                data.finger.as_finger_id(),
                 &data.username,
                 &mut output,
             )

--- a/src/app/subscription.rs
+++ b/src/app/subscription.rs
@@ -104,10 +104,20 @@ pub(crate) fn verify_subscription(data: VerifyData) -> Subscription<Message> {
     Subscription::run_with(data, |data| {
         let data = data.clone();
         channel(100, move |mut output: Sender<Message>| async move {
+            let Some(finger_id) = data.finger.as_finger_id() else {
+                let _ = output
+                    .send(Message::OperationError(AppError::Unknown(
+                        "Cannot verify: no valid finger selected".to_string(),
+                    )))
+                    .await;
+                futures_util::future::pending::<()>().await;
+                return;
+            };
+
             match verify_finger_process(
                 data.connection,
                 &data.device_path,
-                data.finger.as_finger_id().unwrap_or_default(),
+                finger_id,
                 &data.username,
                 &mut output,
             )

--- a/src/app/subscription.rs
+++ b/src/app/subscription.rs
@@ -169,7 +169,10 @@ pub fn portal_theme_subscription(app_theme: crate::config::AppTheme) -> Subscrip
 
 /// **Returns** a subscription to key events 0-9, r, v, c, Ctrl + d/,/q and F1
 pub fn key_subscription() -> Subscription<Message> {
-    cosmic::iced::event::listen_raw(|event, _status, _window| {
+    cosmic::iced::event::listen_raw(|event, status, _window| {
+        if status == cosmic::iced::event::Status::Captured {
+            return None;
+        }
         let Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) = event else {
             return None;
         };

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -72,13 +72,13 @@ pub fn get_devices_task(conn: zbus::Connection) -> Task<cosmic::Action<Message>>
                 Ok(paths) => {
                     let mut devices = Vec::new();
                     for path in paths {
-                        let name = match DeviceProxy::builder(&conn)
-                            .path(path.clone())
-                            .unwrap()
-                            .build()
-                            .await
-                        {
-                            Ok(proxy) => proxy.name().await.unwrap_or_else(|_| path.to_string()),
+                        let name = match DeviceProxy::builder(&conn).path(path.clone()) {
+                            Ok(builder) => match builder.build().await {
+                                Ok(proxy) => {
+                                    proxy.name().await.unwrap_or_else(|_| path.to_string())
+                                }
+                                Err(_) => path.to_string(),
+                            },
                             Err(_) => path.to_string(),
                         };
                         devices.push(DeviceOption { path, name });
@@ -183,13 +183,11 @@ pub fn task_select_device(
 ) -> Task<cosmic::Action<Message>> {
     Task::perform(
         async move {
-            match DeviceProxy::builder(&conn)
-                .path(path.clone())
-                .unwrap()
-                .build()
-                .await
-            {
-                Ok(proxy) => Message::DeviceFound(Some((path, proxy))),
+            match DeviceProxy::builder(&conn).path(path.clone()) {
+                Ok(builder) => match builder.build().await {
+                    Ok(proxy) => Message::DeviceFound(Some((path, proxy))),
+                    Err(e) => Message::OperationError(AppError::from(e)),
+                },
                 Err(e) => Message::OperationError(AppError::from(e)),
             }
         },

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -5,6 +5,7 @@ use crate::app::{
     error::AppError,
     fprint::*,
     message::{DeviceOption, Message},
+    users::fetch_users,
 };
 use crate::{fl, fprint_dbus::*};
 use cosmic::{ApplicationExt, Task};
@@ -224,6 +225,14 @@ pub fn task_connect() -> Task<cosmic::Action<Message>> {
                 Err(e) => Message::OperationError(AppError::ConnectDbus(e.to_string())),
             }
         },
+        cosmic::Action::App,
+    )
+}
+
+/// **Returns** ***Task*** which fetches users from accounts-daemon asynchronously
+pub fn task_load_users() -> Task<cosmic::Action<Message>> {
+    Task::perform(
+        async move { Message::UsersLoaded(fetch_users().await) },
         cosmic::Action::App,
     )
 }

--- a/src/app/users.rs
+++ b/src/app/users.rs
@@ -1,29 +1,27 @@
 // SPDX-License-Identifier: MPL-2.0
 
-pub(crate) use crate::accounts_dbus::{AccountsProxyBlocking, UserProxyBlocking};
+pub(crate) use crate::accounts_dbus::{AccountsProxy, UserProxy};
 use cosmic::widget::{icon, nav_bar};
 use nix::unistd::{Uid, User};
 use std::sync::Arc;
 
-/// Uses DBus synchronously to initialize users, also creates nav_bar with information
+/// Fetches users from accounts-daemon asynchronously.
 ///
-/// Was an asynchronous task but chose that I'd like initialize nav_bar before use
-///
-/// **Returns** tuple of users, nav and current user
-pub fn initialize_users() -> (Vec<UserOption>, nav_bar::Model, Option<UserOption>) {
+/// **Returns** list of users
+pub async fn fetch_users() -> Vec<UserOption> {
     let mut users = Vec::new();
 
-    if let Ok(conn) = zbus::blocking::Connection::system()
-        && let Ok(accounts) = AccountsProxyBlocking::new(&conn)
-        && let Ok(user_paths) = accounts.list_cached_users()
+    if let Ok(conn) = zbus::Connection::system().await
+        && let Ok(accounts) = AccountsProxy::new(&conn).await
+        && let Ok(user_paths) = accounts.list_cached_users().await
     {
         for path in user_paths {
-            if let Ok(builder) = UserProxyBlocking::builder(&conn).path(&path)
-                && let Ok(user_proxy) = builder.build()
+            if let Ok(builder) = UserProxy::builder(&conn).path(&path)
+                && let Ok(user_proxy) = builder.build().await
                 && let (Ok(name), Ok(real_name), Ok(icon)) = (
-                    user_proxy.user_name(),
-                    user_proxy.real_name(),
-                    user_proxy.icon_file(),
+                    user_proxy.user_name().await,
+                    user_proxy.real_name().await,
+                    user_proxy.icon_file().await,
                 )
             {
                 users.push(UserOption {
@@ -35,15 +33,21 @@ pub fn initialize_users() -> (Vec<UserOption>, nav_bar::Model, Option<UserOption
         }
     }
 
-    let mut nav = nav_bar::Model::default();
+    users
+}
 
+/// Builds the nav bar model from a list of users and selects the current user.
+///
+/// **Returns** tuple of nav model and selected user
+pub fn build_nav(users: &[UserOption]) -> (nav_bar::Model, Option<UserOption>) {
+    let mut nav = nav_bar::Model::default();
     let mut selected_user = None;
     let current_username = User::from_uid(Uid::current())
         .ok()
         .flatten()
         .map(|u| u.name);
 
-    for user_opt in &users {
+    for user_opt in users {
         let mut item = nav.insert().text(user_opt.to_string());
         let mut icon_str = user_opt.icon.as_str();
 
@@ -72,7 +76,7 @@ pub fn initialize_users() -> (Vec<UserOption>, nav_bar::Model, Option<UserOption
             selected_user = Some(user_opt.clone());
         }
     }
-    (users, nav, selected_user)
+    (nav, selected_user)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -192,7 +192,7 @@ impl AppModel {
         button::custom_image_button(container, None)
             .width(40)
             .height(Length::Fixed(height))
-            .on_press(Message::FingerSelected(finger.localized_name()))
+            .on_press(Message::FingerSelected(finger))
             .selected(is_selected)
             .into()
     }
@@ -235,16 +235,10 @@ impl AppModel {
     ///
     /// **Returns** pick_list widget with all Fingers localized names
     pub(crate) fn view_finger_picker(&self) -> Option<Element<'_, Message>> {
-        let mut vec = Vec::new();
-
-        for page in Finger::all() {
-            vec.push(page.localized_name())
-        }
-
         Some(
             pick_list(
-                vec,
-                Some(self.selected_finger.localized_name()),
+                Finger::all().to_vec(),
+                Some(self.selected_finger),
                 Message::FingerSelected,
             )
             .width(Length::Fixed(200.0))

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -123,7 +123,7 @@ impl AppModel {
             .spacing(10)
             .align_y(Vertical::Bottom);
 
-        let mut column = Column::new();
+        let mut column = Column::new().push(widget::space().height(Length::Fill));
 
         if self.core.is_condensed() {
             column = column
@@ -132,27 +132,27 @@ impl AppModel {
                         .width(Length::Fill)
                         .align_x(Horizontal::Center)
                         .align_y(Vertical::Center)
-                        .padding(MAIN_PADDING),
+                        .padding([0, MAIN_PADDING]),
                 )
                 .push(
                     container(right_hand)
                         .width(Length::Fill)
                         .align_x(Horizontal::Center)
                         .align_y(Vertical::Center)
-                        .padding(MAIN_PADDING),
+                        .padding([0, MAIN_PADDING]),
                 );
         } else {
             let hands = Row::new()
                 .push(left_hand)
                 .push(right_hand)
-                .spacing(50)
+                .spacing(MAIN_SPACING)
                 .align_y(Vertical::Bottom);
             column = column.push(
                 container(hands)
                     .width(Length::Fill)
                     .align_x(Horizontal::Center)
                     .align_y(Vertical::Center)
-                    .padding(MAIN_PADDING),
+                    .padding([MAIN_PADDING, MAIN_PADDING]),
             );
         }
         column = column.push(self.view_status());
@@ -163,6 +163,7 @@ impl AppModel {
 
         column
             .push(self.view_controls())
+            .push(widget::space().height(Length::Fill))
             .align_x(Horizontal::Center)
             .spacing(MAIN_SPACING)
             .padding(MAIN_PADDING)
@@ -295,15 +296,16 @@ impl AppModel {
     pub(crate) fn view_controls(&self) -> Element<'_, Message> {
         let buttons_enabled =
             !self.busy && self.device_path.is_some() && self.enrolling_finger.is_none();
+        let cosmic_theme::Spacing { space_s, .. } = theme::active().cosmic().spacing;
 
         let is_enrolled = self
             .enrolled_fingers
             .iter()
             .any(|ef| ef == self.selected_finger.as_finger_id());
 
-        let register_btn = button::text(fl!("register")).tooltip(fl!("register-tooltip"));
-        let verify_btn = button::text(fl!("verify")).tooltip(fl!("verify-tooltip"));
-        let delete_btn = button::text(fl!("delete")).tooltip(fl!("delete-tooltip"));
+        let register_btn = button::suggested(fl!("register")).tooltip(fl!("register-tooltip"));
+        let verify_btn = button::standard(fl!("verify")).tooltip(fl!("verify-tooltip"));
+        let delete_btn = button::destructive(fl!("delete")).tooltip(fl!("delete-tooltip"));
 
         let register_btn = if buttons_enabled {
             register_btn.on_press(Message::Register)
@@ -323,7 +325,7 @@ impl AppModel {
             delete_btn
         };
 
-        let mut cancel_btn = button::text(fl!("cancel"));
+        let mut cancel_btn = button::standard(fl!("cancel"));
         if self.enrolling_finger.is_some() {
             cancel_btn = cancel_btn.on_press(Message::EnrollStop);
         } else if self.verifying_finger {
@@ -333,7 +335,8 @@ impl AppModel {
         let mut row = Row::new()
             .push(register_btn)
             .push(verify_btn)
-            .push(delete_btn);
+            .push(delete_btn)
+            .spacing(space_s);
 
         if self.enrolling_finger.is_some() || self.verifying_finger {
             row = row.push(cancel_btn);
@@ -341,10 +344,8 @@ impl AppModel {
 
         row.apply(container)
             .width(Length::Fill)
-            .height(Length::Fill)
             .align_x(Horizontal::Center)
-            .align_y(Vertical::Center)
-            .padding(MAIN_PADDING)
+            .padding([MAIN_PADDING, MAIN_PADDING])
             .into()
     }
 }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -174,9 +174,10 @@ impl AppModel {
     /// **Returns** an instance of custom_image_button widget
     fn finger_button(&self, finger: Finger, height: f32) -> Element<'_, Message> {
         let is_selected = self.selected_finger == finger;
-        let is_enrolled = finger
-            .as_finger_id()
-            .is_some_and(|id| self.enrolled_fingers.iter().any(|ef| ef == id));
+        let is_enrolled = self
+            .enrolled_fingers
+            .iter()
+            .any(|ef| ef == finger.as_finger_id());
         let mut svg = svg(svg::Handle::from_memory(FPRINT_ICON)).symbolic(true);
         let label = text(finger.localized_name()).size(10);
         if is_enrolled {
@@ -295,18 +296,16 @@ impl AppModel {
         let buttons_enabled =
             !self.busy && self.device_path.is_some() && self.enrolling_finger.is_none();
 
-        let current_finger = self.selected_finger.as_finger_id();
-        let is_enrolled = if let Some(f) = current_finger {
-            self.enrolled_fingers.iter().any(|ef| ef == f)
-        } else {
-            !self.enrolled_fingers.is_empty()
-        };
+        let is_enrolled = self
+            .enrolled_fingers
+            .iter()
+            .any(|ef| ef == self.selected_finger.as_finger_id());
 
         let register_btn = button::text(fl!("register")).tooltip(fl!("register-tooltip"));
         let verify_btn = button::text(fl!("verify")).tooltip(fl!("verify-tooltip"));
         let delete_btn = button::text(fl!("delete")).tooltip(fl!("delete-tooltip"));
 
-        let register_btn = if buttons_enabled && current_finger.is_some() {
+        let register_btn = if buttons_enabled {
             register_btn.on_press(Message::Register)
         } else {
             register_btn

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,6 @@ mod config;
 mod fprint_dbus;
 mod i18n;
 
-extern crate ashpd;
-extern crate tracing;
-extern crate zbus;
-
 const WINDOW_MIN_WIDTH: f32 = 360.0;
 const WINDOW_MIN_HEIGHT: f32 = 600.0;
 


### PR DESCRIPTION
Adds guards so that keyboard shorcuts don't work when they shouldn't. Fixes a few panics by removing unwraps. Reduced unnecessary cloning.

Also now uses suggestively styled buttons appropriate for the actions; not just text ones. So that whatever libcosmic deems to be appropriate for those is matched.

Finally removed some lines that were unnecessary in modern Rust.