### PR TITLE
fix: on_error sets verifying_finger to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Failed Verify (due to busy device etc) no longer displays the Cancel button.
+
 ## [1.2.3](https://github.com/cosmic-utils/enroll/releases/tag/v1.2.3) - 2026-08-03
 
 ### Fixed

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -151,6 +151,7 @@ impl AppModel {
             self.status = err.localized_message();
         }
         self.busy = false;
+        self.verifying_finger = false;
         self.enrolling_finger = None;
         Task::none()
     }


### PR DESCRIPTION
Verify logic was added later and this spot was missed. It just set enrolling_finger to None. 

Resulted in correct status message being displayed but the view state not reflecting this as Cancel button is rendered when verifying_finger is true.

Fixes #195.